### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -9,6 +9,8 @@ jobs:
   cleanup:
     name: Cleanup Caches
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - name: Cleanup
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 0 * * 0'  # Run weekly on Sunday at midnight
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fponticelli/tml/security/code-scanning/3](https://github.com/fponticelli/tml/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only checks Markdown links, it does not require write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
